### PR TITLE
fix: Ensure customer components are not standalone

### DIFF
--- a/src/app/pages/customer/customer-add/customer-add.component.ts
+++ b/src/app/pages/customer/customer-add/customer-add.component.ts
@@ -6,7 +6,8 @@ import { CustomerService } from '../services/customer.service';
 @Component({
   selector: 'app-customer-add',
   templateUrl: './customer-add.component.html',
-  styleUrls: ['./customer-add.component.css']
+  styleUrls: ['./customer-add.component.css'],
+  standalone: false, // Explicitly set to false
 })
 export class CustomerAddComponent implements OnInit {
   customerForm!: FormGroup;

--- a/src/app/pages/customer/customer-edit/customer-edit.component.ts
+++ b/src/app/pages/customer/customer-edit/customer-edit.component.ts
@@ -7,7 +7,8 @@ import { Customer } from '../models/customer.model';
 @Component({
   selector: 'app-customer-edit',
   templateUrl: './customer-edit.component.html',
-  styleUrls: ['./customer-edit.component.css']
+  styleUrls: ['./customer-edit.component.css'],
+  standalone: false, // Explicitly set to false
 })
 export class CustomerEditComponent implements OnInit {
   customerForm!: FormGroup;

--- a/src/app/pages/customer/customer-list/customer-list.component.ts
+++ b/src/app/pages/customer/customer-list/customer-list.component.ts
@@ -6,7 +6,8 @@ import { CustomerService } from '../services/customer.service';
 @Component({
   selector: 'app-customer-list',
   templateUrl: './customer-list.component.html',
-  styleUrls: ['./customer-list.component.css'] // Note: styleUrls, not styleUrl for non-standalone
+  styleUrls: ['./customer-list.component.css'],
+  standalone: false, // Explicitly set to false
 })
 export class CustomerListComponent implements OnInit {
   customerList: Customer[] = [];


### PR DESCRIPTION
- Explicitly set `standalone: false` in the @Component decorator for CustomerListComponent, CustomerAddComponent, and CustomerEditComponent.
- This resolves the TS-996008 error caused by these components being incorrectly treated as standalone while also being declared in CustomerModule.